### PR TITLE
CID-11929: Update gha-store-artifacts to v2.0.4

### DIFF
--- a/.github/workflows/_gha_build.yaml
+++ b/.github/workflows/_gha_build.yaml
@@ -21,7 +21,7 @@ jobs:
       # store artifacts action uploads a build.txt and marks the
       # github action run as "the build" for integration with
       # workiva release pipelines
-      - uses: Workiva/gha-store-artifacts@v2.0.1
+      - uses: Workiva/gha-store-artifacts@v2.0.4
   test:
     runs-on: [self-hosted, xs, al2023]
     steps:


### PR DESCRIPTION
## JIRA Ticket
[CID-11929](https://jira.atl.workiva.net/browse/CID-11929)

## Description
Update gha-store-artifacts to allow it to replace the features currently being
supported by Skynet core-checks. Once the organization has moved to using v2.0.4
the BTR team will be able to archive the core-checks repository and remove the
AWS resources currently being used to execute core-checks.


## What to test
Ensure Github Actions workflows are passing. Please direct any questions about 
this change to the #github-actions slack channel.

[_Created by Sourcegraph batch change `Workiva/CID-11929`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/CID-11929)