### PR TITLE
FEDX-1313: bumped dependency validator version

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -50,7 +50,7 @@ jobs:
           sdk: ${{ inputs.sdk }}
 
       - name: Install Dependency Validator
-        run: dart pub global activate dependency_validator ^3.2.3
+        run: dart pub global activate dependency_validator ^4.1.0
 
       - name: Install Package Dependencies
         working-directory: ${{ inputs.package-path }}


### PR DESCRIPTION
# [FEDX-1313](https://jira.atl.workiva.net/browse/FEDX-1313)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1313)

dep validator has recently gone through a major, this pr bumps it's chosen version so we can resolve to the latest version