### PR TITLE
FEDX-1319: Updated dependabot config to leverage glob syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "pub"
-    directory: "/__tests__/fixtures/checks"
+  - package-ecosystem: pub
+    directories:
+      - "**/*"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "pub"
-    directory: "/__tests__/fixtures/test-unit/with-chrome"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pub"
-    directory: "/__tests__/fixtures/test-unit/without-chrome"
-    schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      pub:
+        patterns: ["*"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     groups:
-      all:
+      github-actions:
         patterns: ["*"]


### PR DESCRIPTION
# [FEDX-1319](https://jira.atl.workiva.net/browse/FEDX-1319)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1319)

dependabot now supports glob syntax: https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/

This pr updates the dependabot config within gha-dart-oss to use this new globing syntax