### PR TITLE
FEDX-1399: Added validate publish to checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,7 +62,7 @@ jobs:
   validate-publish:
     runs-on: ubuntu-latest
     # only run on release pull requests
-    if: ${{ startsWith(github.ref, 'refs/head/release') && github.event.sender == 'rmconsole-readonly-wk' }}
+    if: ${{ startsWith(github.ref, 'refs/head/release') && contains(github.event.sender, 'rmconsole') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,6 @@ jobs:
       - working-directory: ${{ inputs.package-path }}
         run: dart run dart_dev analyze
 
-
   format:
     runs-on: ubuntu-latest
     steps:
@@ -59,6 +58,17 @@ jobs:
       - name: Run Dependency Validator
         working-directory: ${{ inputs.package-path }}
         run: dart pub global run dependency_validator
+
+  validate-publish:
+    runs-on: ubuntu-latest
+    # only run on release pull requests
+    if: ${{ startsWith(github.ref, 'refs/head/release') && github.event.sender == 'rmconsole-readonly-wk' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ inputs.sdk }}
+      - run: dart pub publish --dry-run
 
   analyze-additional-checks:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -45,11 +45,3 @@ jobs:
   publish:
     uses: Workiva/gha-dart-oss/.github/workflows/publish@v1.0.0
 ```
-
-```yaml
-name: Validate Publish
-
-on:
-  pull_request:
-
-```

--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ jobs:
   publish:
     uses: Workiva/gha-dart-oss/.github/workflows/publish@v1.0.0
 ```
+
+```yaml
+name: Validate Publish
+
+on:
+  pull_request:
+
+```


### PR DESCRIPTION
# [FEDX-1399](https://jira.atl.workiva.net/browse/FEDX-1399)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1399)

Currently its possible to merge a release PR in a state that will fail `dart pub publish`

This PR runs a publish validation for only release PRs so we don't get silent errors