### PR TITLE
Removed validate publish check

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -59,17 +59,6 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: dart pub global run dependency_validator
 
-  validate-publish:
-    runs-on: ubuntu-latest
-    # only run on release pull requests
-    if: ${{ startsWith(github.ref, 'refs/head/release') && contains(github.event.sender, 'rmconsole') }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: ${{ inputs.sdk }}
-      - run: dart pub publish --dry-run
-
   analyze-additional-checks:
     runs-on: ubuntu-latest
     if: inputs.additional-checks != ''

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gha-dart-oss
 
-Workflows for use with [Workiva's](https://github.com/Workiva) OpenSource Dart projects.
+A set of opinionated github actions/workflows to use on OSS packages at [Workiva's](https://github.com/Workiva)
 
 The majority of workflows assume [dart_dev](https://github.com/Workiva/dart_dev) is installed and being used within the repo
 
@@ -25,6 +25,16 @@ jobs:
   # Runs unit tests in both d2js and ddc
   unit-tests:
     uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v1.0.0
+
+  # for release PRs, ensures that once they merge, the publish action will work
+  validate-publish:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/heads/<your release branch prefix>/') }}
+    steps:
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 2.19.0
+      - run: dart pub publish --dry-run
 ```
 
 ```yaml


### PR DESCRIPTION
The `checks/validate` job that was added in #13 , just simply did not work: https://github.com/Workiva/scip-dart/pull/136 (it was still skipped: https://github.com/Workiva/scip-dart/actions/runs/10321235192/job/28573706991?pr=136)

Because of this, the current suggestion will be to just implement a `dart pub publish --dry-run` call within each oss dart repo, based on the pre-existing publish setup.

This will probably look something like:

```yaml
name: Publish PR

on:
  pull_request:

jobs:
  validate-publish:
    runs-on: ubuntu-latest
    if: if: ${{ startsWith(github.ref, 'refs/heads/<your release branch prefix>/') }}
    steps:
       - uses: dart-lang/setup-dart@v1
          with:
            sdk: 2.19.0
      - run: dart pub publish --dry-run
```

If we come up with more ideas to add to a "on publish" or publish validation, we can always re-add this concept, maybe as a re-usable workflow? or make the checks workflow more extendable?