### PR TITLE
FEDX-1472: added build action and fixed publish validate

### DIFF
--- a/.github/workflows/_test:build.yaml
+++ b/.github/workflows/_test:build.yaml
@@ -1,0 +1,17 @@
+name: 🧪 build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - __tests__/fixtures/build/**
+      - .github/workflows/build.yaml
+      - .github/workflows/_test:build.yaml
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    with:
+      package-path: __tests__/fixtures/build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    inputs:
+      package-path:
+        description: The path to the package to build
+        default: '.'
+        type: string
+
+      sdk:
+        description: See https://github.com/dart-lang/setup-dart
+        default: 2.19.6
+        type: string
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ inputs.sdk }}
+      - working-directory: ${{ inputs.package-path }}
+        run: dart pub get
+      - uses: anchore/sbom-action@v0
+        with:
+          path: ${{ inputs.package-path}}
+          format: cyclonedx-json

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -61,14 +61,21 @@ jobs:
 
   validate-publish:
     runs-on: ubuntu-latest
-    # only run on release pull requests
-    if: ${{ startsWith(github.ref, 'refs/head/release') && contains(github.event.sender, 'rmconsole') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ inputs.sdk }}
-      - run: dart pub publish --dry-run
+      - id: analyze-pubspec
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          echo "package_name=$(yq '.name' pubspec.yaml)" >> $GITHUB_OUTPUT
+          echo "package_version=$(yq '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Validate Publish
+        # Only validate the publish for release pull requests, as determined by the branch name
+        if: github.ref == format('refs/head/release_{0}_{1}', steps.analyze-pubspec.outputs.package_name, steps.analyze-pubspec.outputs.package_version)
+        run: dart pub publish --dry-run
 
   analyze-additional-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      package-path:
+        description: The path to the package to publish
+        default: '.'
+        type: string
+
       sdk:
         description: See https://github.com/dart-lang/setup-dart
         default: 2.19.6
@@ -12,11 +17,16 @@ permissions:
   pull-requests: write
 
 jobs:
-  create-sbom-release-asset:
+  sbom:
     name: Create SBOM Release Asset
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ inputs.sdk }}
+      - working-directory: ${{ inputs.package-path }}
+        run: dart pub get
       - name: Publish SBOM to Release Assets
         uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -44,10 +44,10 @@ jobs:
       has-chrome-platform: ${{ steps.analyze.outputs.HAS_CHROME_PLATFORM }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install yq
-        run: |
-          sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+      # - name: Install yq
+      #   run: |
+      #     sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+      #     sudo chmod +x /usr/local/bin/yq
       - working-directory: ${{ inputs.package-path }}
         id: analyze
         run: |

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -44,10 +44,6 @@ jobs:
       has-chrome-platform: ${{ steps.analyze.outputs.HAS_CHROME_PLATFORM }}
     steps:
       - uses: actions/checkout@v4
-      # - name: Install yq
-      #   run: |
-      #     sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-      #     sudo chmod +x /usr/local/bin/yq
       - working-directory: ${{ inputs.package-path }}
         id: analyze
         run: |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ jobs:
   checks:
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v1.0.0
 
+  # Generates sbom and uploads it using anchore/sbom-action
+  build:
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v1.0.0
+
   # Runs unit tests in both d2js and ddc
   unit-tests:
     uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v1.0.0

--- a/__tests__/fixtures/build/lib/main.dart
+++ b/__tests__/fixtures/build/lib/main.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('Hello World!');
+}

--- a/__tests__/fixtures/build/pubspec.yaml
+++ b/__tests__/fixtures/build/pubspec.yaml
@@ -1,0 +1,7 @@
+name: build_test
+publish_to: none
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dev_dependencies:
+  dart_dev: ^4.1.1


### PR DESCRIPTION
# [FEDX-1472](https://jira.atl.workiva.net/browse/FEDX-1472)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1472)

- Added a `build.yaml` action to facilitate providing an sbom as required by our build system
- Fixed issues with publish validation, where we determine the branch name of the release PR by using the current pubspec.yaml's version and name fields
- Minor cleanup, thanks to yq being installed everywhere by defailt
