### PR TITLE
FEDX-1583: pub get analyze

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,6 +26,10 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ inputs.sdk }}
+
+      - working-directory: ${{ inputs.package-path }}
+        run: dart pub get
+
       - working-directory: ${{ inputs.package-path }}
         run: |
           if (grep -q "^  dart_dev:" pubspec.yaml); then


### PR DESCRIPTION
# [FEDX-1583](https://jira.atl.workiva.net/browse/FEDX-1583)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1583)

`dart analyze .` doesn't automatically run `dart pub get` before execution like `dart run dart_dev analyze` does

This means repos that aren't setup to use dart_dev will not correctly install dependencies, and cause their analysis to fail

For simplicity, this PR just runs `dart pub get` within the analyze check, for both cases

## QA

- Verify analysis passes for this PR: https://github.com/Workiva/webdev_proxy/pull/45