### PR TITLE
FEDX-1599: fixed validation publish condition

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -78,6 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+        id: setup-dart
         with:
           sdk: ${{ inputs.sdk }}
       - id: analyze-pubspec
@@ -86,16 +87,28 @@ jobs:
           PACKAGE_NAME=$(yq '.name' pubspec.yaml)
           PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
 
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
           echo "release_ref=release_${PACKAGE_NAME}_${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
 
+      # Only validate the publish for release pull requests, as determined by the branch name
       - name: Debug
         run: |
+          echo "Dart Version: ${{ steps.setup-dart.outputs.dart-version }}"
           echo "Current Ref: ${{ github.head_ref }}"
           echo "Analyzed Release Ref: ${{ steps.analyze-pubspec.outputs.release_ref }}"
 
-      - name: Validate Publish
-        # Only validate the publish for release pull requests, as determined by the branch name
-        if: github.head_ref == steps.analyze-pubspec.outputs.release_ref
+      # dart v2's `dart pub publish --dry-run` runs `dart analyze --fatal-infos`. This was updated in dart3
+      # (see: https://github.com/dart-lang/pub/pull/3877). Because "infos" are not a valid failure condition
+      # we need to emulate the behavior of `dart pub publish --dry-run` for dart v2.
+      - name: Validate Publish (dart v2)
+        if: startsWith(steps.setup-dart.outputs.dart-version, '2') && github.head_ref == steps.analyze-pubspec.outputs.release_ref
+        run: |
+          grep -q "## ${{ steps.analyze-pubspec.outputs.package_version }}" CHANGELOG.md || {
+            echo "::error::CHANGELOG.md does not contain a section for version $PACKAGE_VERSION"
+            exit 1
+          }
+      - name: Validate Publish (dart v3)
+        if: startsWith(steps.setup-dart.outputs.dart-version, '3') && github.head_ref == steps.analyze-pubspec.outputs.release_ref
         run: dart pub publish --dry-run
 
   analyze-additional-checks:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -85,16 +85,17 @@ jobs:
         run: |
           PACKAGE_NAME=$(yq '.name' pubspec.yaml)
           PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
+
           echo "release_ref=refs/head/release_$PACKAGE_NAME_$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug
         run: |
-          echo "Current Ref: ${{ github.ref}}"
+          echo "Current Ref: ${{ github.head_ref }}"
           echo "Analyzed Release Ref: ${{ steps.analyze-pubspec.outputs.release_ref }}"
 
       - name: Validate Publish
         # Only validate the publish for release pull requests, as determined by the branch name
-        if: github.ref == steps.analyze-pubspec.outputs.release_ref
+        if: github.head_ref == steps.analyze-pubspec.outputs.release_ref
         run: dart pub publish --dry-run
 
   analyze-additional-checks:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           PACKAGE_NAME=$(yq '.name' pubspec.yaml)
           PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
-          echo "release_ref=refs/head/release_$PACKAGE_NAME_$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "release_ref=refs/head/release_$PACKAGE_NAME_$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -86,7 +86,7 @@ jobs:
           PACKAGE_NAME=$(yq '.name' pubspec.yaml)
           PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
 
-          echo "release_ref=refs/head/release_$PACKAGE_NAME_$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "release_ref=release_${PACKAGE_NAME}_${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Debug
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -83,12 +83,18 @@ jobs:
       - id: analyze-pubspec
         working-directory: ${{ inputs.package-path }}
         run: |
-          echo "package_name=$(yq '.name' pubspec.yaml)" >> $GITHUB_OUTPUT
-          echo "package_version=$(yq '.version' pubspec.yaml)" >> $GITHUB_OUTPUT
+          PACKAGE_NAME=$(yq '.name' pubspec.yaml)
+          PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
+          echo "release_ref=refs/head/release_$PACKAGE_NAME_$PACKAGE_VERSION" >> $GITHUB_ENV
+
+      - name: Debug
+        run: |
+          echo "Current Ref: ${{ github.ref}}"
+          echo "Analyzed Release Ref: ${{ steps.analyze-pubspec.outputs.release_ref }}"
 
       - name: Validate Publish
         # Only validate the publish for release pull requests, as determined by the branch name
-        if: github.ref == format('refs/head/release_{0}_{1}', steps.analyze-pubspec.outputs.package_name, steps.analyze-pubspec.outputs.package_version)
+        if: github.ref == steps.analyze-pubspec.outputs.release_ref
         run: dart pub publish --dry-run
 
   analyze-additional-checks:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,14 +39,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+        id: setup-dart
         with:
           sdk: ${{ inputs.sdk }}
 
       - name: Install dependencies
         run: dart pub get
 
-      - name: Publish - dry run
-        run: dart pub publish --dry-run
+      # For dart 2, we have to force publish because `analyze --fatal-infos` is ran.
+      # This was fixed in dart 3, so we don't need to force publish for this version
+      - name: Publish (dart 2)
+        if: startsWith(steps.setup-dart.outputs.dart-version, '2')
+        run: dart pub publish --force
 
-      - name: Publish
-        run: dart pub publish -f
+      - name: Publish (dart 3)
+        if: startsWith(steps.setup-dart.outputs.dart-version, '3')
+        run: dart pub publish


### PR DESCRIPTION
# [FEDX-1599](https://jira.atl.workiva.net/browse/FEDX-1599)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1599)

Pre dart 3, running `dart pub publish --dry-run` would transitively execute `dart analyze --fatal-infos` under the assumption that all info lints should be resolved before publishing a dart package

There is an escape hatch `--force` where this check was ignored.

This was decided overkill, and just `dart analyze` is now run in dart. This change was applied in dart 3

Since we commonly index/publish dart 2 packages in gha-dart-oss, we have to support both approaches, and `--fatal-infos` is a stopgap for the action. 

As a solution, we've decided to write custom validation steps for dart 2 for the criteria that we want to enforce (specifically the changelog update), and for dart 3, continue to use `dart pub publish --dry-run`

On the publish side of things, we need to `--force` publish for dart 2, but dart 3 should be able to publish without issue