### PR TITLE
FEDX-1601: Fixed issue where changlogs can have inconsistent formats

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Validate Publish (dart v2)
         if: startsWith(steps.setup-dart.outputs.dart-version, '2') && github.head_ref == steps.analyze-pubspec.outputs.release_ref
         run: |
-          grep -q "## ${{ steps.analyze-pubspec.outputs.package_version }}" CHANGELOG.md || {
+          grep -q "# ${{ steps.analyze-pubspec.outputs.package_version }}" CHANGELOG.md || {
             echo "::error::CHANGELOG.md does not contain a section for version $PACKAGE_VERSION"
             exit 1
           }


### PR DESCRIPTION
# [FEDX-1601](https://jira.atl.workiva.net/browse/FEDX-1601)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1601)

Dart changelogs do not have to have consistent version header nesting:
- https://github.com/Workiva/dependency_validator/blob/master/CHANGELOG.md?plain=1#L1
- https://github.com/Workiva/dart_dev/blob/master/CHANGELOG.md?plain=1#L3

Instead of strictly checking `##`, this PR updates the validate-publish job to only check for `# <version>`, this will match any depth markdown header