### PR TITLE
FEDX-1659: Fixed release matching on validate-publish

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -84,11 +84,10 @@ jobs:
       - id: analyze-pubspec
         working-directory: ${{ inputs.package-path }}
         run: |
-          PACKAGE_NAME=$(yq '.name' pubspec.yaml)
           PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
 
           echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-          echo "release_ref=release_${PACKAGE_NAME}_${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "release_ref=release_${{ github.event.repository.name }}_${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
 
       # Only validate the publish for release pull requests, as determined by the branch name
       - name: Debug


### PR DESCRIPTION
# [FEDX-1659](https://jira.atl.workiva.net/browse/FEDX-1659)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1659)

I discovered that release branches use repo name, and not dart package name, this was causing publish validation to not work with packages not named the same as their repos

Example: https://github.com/Workiva/scip-dart/actions/runs/11034842608/job/30649389405?pr=150#step:5:12

This PR resolves that problem by leveraging github's context

## QA

- verify that "validate-publish" fails on this pr: https://github.com/Workiva/scip-dart/pull/150