### PR TITLE
Implemented different release notes process

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -87,6 +87,8 @@ jobs:
     steps:      
       - uses: actions/checkout@v4
       - id: should-skip
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           LABELS=$(gh api --jq '.labels.[].name' /repos/{owner}/{repo}/pulls/${{ github.event.number }})
           SKIP=$(echo "$LABELS" | grep -q "ignore release notes" && echo "true" || echo "false")

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -108,43 +108,6 @@ jobs:
           echo "::error::Add a new entry to the 'Unreleased' section, or add an 'ignore release notes' label to this PR"
           exit 1
 
-  validate-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-        id: setup-dart
-        with:
-          sdk: ${{ inputs.sdk }}
-      - id: analyze-pubspec
-        working-directory: ${{ inputs.package-path }}
-        run: |
-          PACKAGE_VERSION=$(yq '.version' pubspec.yaml)
-
-          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-          echo "release_ref=release_${{ github.event.repository.name }}_${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
-
-      # Only validate the publish for release pull requests, as determined by the branch name
-      - name: Debug
-        run: |
-          echo "Dart Version: ${{ steps.setup-dart.outputs.dart-version }}"
-          echo "Current Ref: ${{ github.head_ref }}"
-          echo "Analyzed Release Ref: ${{ steps.analyze-pubspec.outputs.release_ref }}"
-
-      # dart v2's `dart pub publish --dry-run` runs `dart analyze --fatal-infos`. This was updated in dart3
-      # (see: https://github.com/dart-lang/pub/pull/3877). Because "infos" are not a valid failure condition
-      # we need to emulate the behavior of `dart pub publish --dry-run` for dart v2.
-      - name: Validate Publish (dart v2)
-        if: startsWith(steps.setup-dart.outputs.dart-version, '2') && github.head_ref == steps.analyze-pubspec.outputs.release_ref
-        run: |
-          grep -q "# ${{ steps.analyze-pubspec.outputs.package_version }}" CHANGELOG.md || {
-            echo "::error::CHANGELOG.md does not contain a section for version $PACKAGE_VERSION"
-            exit 1
-          }
-      - name: Validate Publish (dart v3)
-        if: startsWith(steps.setup-dart.outputs.dart-version, '3') && github.head_ref == steps.analyze-pubspec.outputs.release_ref
-        run: dart pub publish --dry-run
-
   analyze-additional-checks:
     runs-on: ubuntu-latest
     if: inputs.additional-checks != ''

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -82,6 +82,30 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: dart pub global run dependency_validator
 
+  check-release-notes:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@v4
+      - id: should-skip
+        run: |
+          LABELS=$(gh api --jq '.labels.[].name' /repos/{owner}/{repo}/pulls/${{ github.event.number }})
+          SKIP=$(echo "$LABELS" | grep -q "ignore release notes" && echo "true" || echo "false")
+          echo "skip=$SKIP" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.should-skip.outputs.skip == 'false' }}
+        uses: dorny/paths-filter@v2.11.1
+        id: has-changes
+        with:
+          working-directory: ${{ inputs.package-path }}
+          filters: |
+            changelog:
+              - 'CHANGELOG.md'
+      - if: ${{ steps.has-changes.outputs.changlog == 'false' }}
+        run: |
+          echo "::error::No changes to CHANGELOG.md detected."
+          echo "::error::Add a new entry to the 'Unreleased' section, or add an 'ignore release notes' label to this PR"
+          exit 1
+
   validate-publish:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The current "CHANGELOG.md" check for gha-dart-oss is as follows:
- let any PR go into master without any changes to `CHANGELOG.md`
- On the release PR, check to see if the current version exists in `CHANGELOG.md`, and if it doesn't fail

This implies that the regular process for updating release notes requires backfilling the changelog.md file with content that the specific release tagger might not have context to, and preventing auto-merging of these PRs

A better process would be the expectation that each PR merged into an oss repo modifies the changelog based on the changes they are making (with a label that could be added to the pr for `"ignore release notes"` as an escape hatch). These would be added under an `Unreleased` section. In the release PR, rosie would replace the `## Unreleased` header with the current version

This PR puts the above process into place, expecting that all OSS packages will update their changelogs within the same PR as the feature is getting enabled in