### PR TITLE
FEDX-3412: Added dependabot to skipped authors

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -132,9 +132,7 @@ jobs:
           filters: |
             changelog:
               - 'CHANGELOG.md'
-
-      - run: |
-          echo "${{ toJson(steps.has-changes.outputs) }}"
+              
        # Note: if a changelog.md file doesn't exist in the repo this check will also be skipped
       - if: ${{ steps.has-changes.outputs.changelog == 'false' }}
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -92,7 +92,13 @@ jobs:
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
-            const skippedAuthors = ['rmconsole-readonly-wk', /rmconsole\d?-(wf|wk)/,  'sourcegraph-wk', 'wk-gh-actions-wk'];
+            const skippedAuthors = [
+              'rmconsole-readonly-wk', 
+              /rmconsole\d?-(wf|wk)/,  
+              'sourcegraph-wk', 
+              'wk-gh-actions-wk',
+              'dependabot[bot]',
+            ];
             if (skippedAuthors.some((author) => prAuthor.match(author))) {
               core.info(`PR author (${prAuthor}) is found in the list of skipped authors. Skipping release notes check`)
               core.setOutput('skip', 'true')

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -132,6 +132,9 @@ jobs:
           filters: |
             changelog:
               - 'CHANGELOG.md'
+
+      - run: |
+          echo "${{ toJson(steps.has-changes.outputs) }}"
        # Note: if a changelog.md file doesn't exist in the repo this check will also be skipped
       - if: ${{ steps.has-changes.outputs.changlog == 'false' }}
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -136,7 +136,7 @@ jobs:
       - run: |
           echo "${{ toJson(steps.has-changes.outputs) }}"
        # Note: if a changelog.md file doesn't exist in the repo this check will also be skipped
-      - if: ${{ steps.has-changes.outputs.changlog == 'false' }}
+      - if: ${{ steps.has-changes.outputs.changelog == 'false' }}
         run: |
           echo "::error::No changes to CHANGELOG.md detected."
           echo "::error::Add a new entry to the 'Unreleased' section, or add an 'ignore release notes' label to this PR"


### PR DESCRIPTION
# [FEDX-3412](https://jira.atl.workiva.net/browse/FEDX-3412)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-3412)

We want to skip release notes checks on dependabot PRs

This also fixes a critical bug where the paths-filter output was spelled wrong