### PR TITLE
Fixed bad regex

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -97,7 +97,7 @@ jobs:
               /rmconsole\d?-(wf|wk)/,  
               'sourcegraph-wk', 
               'wk-gh-actions-wk',
-              'dependabot[bot]',
+              /dependabot\[bot\]/,
             ];
             if (skippedAuthors.some((author) => prAuthor.match(author))) {
               core.info(`PR author (${prAuthor}) is found in the list of skipped authors. Skipping release notes check`)


### PR DESCRIPTION
`string.match('...[bot]')` treats `[` as the regex match group. For the skip-release-notes check we want to treat this as the actual character `'['`

This PR updates that