### PR TITLE
FEDX-4265: Added additional-checks to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
         patterns: ["*"]
 
   - package-ecosystem: github-actions
-    directory: /
+    directories: 
+      - /
+      - .github/actions/additional-checks
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
# [FEDX-4265](https://jira.atl.workiva.net/browse/FEDX-4265)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-4265)

The `.github/actions/additional-checks` workflow hasn't seen dependabot updates in awhile

The theory is that `directory: /` only works for workflows, and actions nested in `.github` still need to be manually specified. This update is a validation to that theory

## QA
- CI passes, we need to merge this in order to test it